### PR TITLE
Fill out some more rationale on overflow flags

### DIFF
--- a/proposals/128-bit-arithmetic/Overview.md
+++ b/proposals/128-bit-arithmetic/Overview.md
@@ -293,7 +293,7 @@ with a sequence of two instructions. This gives rise to an alternative to this
 proposal which is to support these instructions individually rather than the
 combined 128-bit operation.
 
-Native platforms have an "overflow flag" in their processor state which
+Many native platforms have an "overflow flag" in their processor state which
 instructions can read and write to. In WebAssembly these instructions for
 addition might look like this for example:
 


### PR DESCRIPTION
This fills out some more in the overview about the alternative for overflow flags. I've expanded the section about how the naive wasm instructions for overflow/add-with-carry are significantly different than hardware to help further explain the complications they cause. I've also noted a "way out there" alternatives to possibly consider.